### PR TITLE
Allow http:// servers

### DIFF
--- a/jpspopulator.py
+++ b/jpspopulator.py
@@ -443,8 +443,10 @@ class User:
 
 class JamfProClient:
     def __init__(self, url, username, password, verify=True):
-        if not url.startswith('https://'):
-            raise Exception("You must provide a URL beginning with 'https://'")
+        if not url.startswith('https://') and not url.startswith('http://'):
+            raise Exception(
+                "You must provide a URL beginning with 'https://' or 'http://'"
+            )
 
         self. url = os.path.join(url, 'JSSResource')
 


### PR DESCRIPTION
My development server runs in [docker](https://github.com/magnusviri/dockerfiles/blob/main/jamfpro/docker-compose.yml) locally, and uses http, not https. This change allows http servers.